### PR TITLE
Some fixes to 2015-12-05-using-c-from-elixir-with-nifs.md

### DIFF
--- a/_posts/2015-12-05-using-c-from-elixir-with-nifs.md
+++ b/_posts/2015-12-05-using-c-from-elixir-with-nifs.md
@@ -312,16 +312,16 @@ db_query_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
 
 ### Using resources in Elixir
 
-Let's skip the part where we export the NIFs we created to a `DB` module and jump right into IEx, assuming the C code is compiled and loaded by `DB`. As I mentioned above, resources are completely opaque terms when returned to Erlang/Elixir. They're represented as empty binaries:
+Let's skip the part where we export the NIFs we created to a `DB` module and jump right into IEx, assuming the C code is compiled and loaded by `DB`. As I mentioned above, resources are completely opaque terms when returned to Erlang/Elixir. They're represented as references:
 
 ```elixir
 iex> conn_res = DB.db_conn_init()
-""
+#Reference<0.3569050097.3772514305.191818>
 iex> DB.db_query(conn_res, ...)
 ...
 ```
 
-Since resources are opaque, you can't really do anything with them in Erlang/Elixir other than passing them back to other NIFs. They act and look like binaries, and this can even cause problems because they can be mistaken for just binaries. For this reason, my advice is to wrap resources inside structs. This way, we can limit our public API to only handle structs and handle resources internally. We also get the benefit of being able to implement the `Inspect` protocol for structs, which means we can safely inspect resources, hiding the fact that they look like empty binaries.
+Since resources are opaque, you can't really do anything with them in Erlang/Elixir other than passing them back to other NIFs. They act and look like references. My advice is to wrap resources inside structs. This way, we can limit our public API to only handle structs and handle resources internally. We also get the benefit of being able to implement the `Inspect` protocol for structs, which means we can safely inspect resources, hiding the fact that they look like references.
 
 ```elixir
 defmodule DBConn do

--- a/_posts/2015-12-05-using-c-from-elixir-with-nifs.md
+++ b/_posts/2015-12-05-using-c-from-elixir-with-nifs.md
@@ -74,7 +74,7 @@ When executing `fast_compare`, `argc` will be `2` and `argv` will be an array wi
 int enif_get_int(ErlNifEnv *env, ERL_NIF_TERM term, int *ip);
 ```
 
-We have to pass in the environment `env`, the Erlang term we want to "get" (which we'll take from `argv`) and the address of an integer pointer that will be filled with the Erlang integer value.
+We have to pass in the environment `env`, the Erlang term we want to "get" (which we'll take from `argv`) and the address of an integer pointer that will be filled with the Erlang integer value. It will return 0 if `term` is not an integer.
 
 ### Turning C values to Erlang values
 
@@ -93,8 +93,10 @@ static ERL_NIF_TERM
 fast_compare(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   int a, b;
   // Fill a and b with the values of the first two args
-  enif_get_int(env, argv[0], &a);
-  enif_get_int(env, argv[1], &b);
+  if (!enif_get_int(env, argv[0], &a) ||
+      !enif_get_int(env, argv[1], &b)) {
+      return enif_make_badarg(env);
+  }
 
   // Usual C unreadable code because this way is more true
   int result = a == b ? 0 : (a > b ? 1 : -1);
@@ -125,8 +127,10 @@ We have all the ingredients we need. The complete C file looks like this:
 static ERL_NIF_TERM
 fast_compare(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   int a, b;
-  enif_get_int(env, argv[0], &a);
-  enif_get_int(env, argv[1], &b);
+  if (!enif_get_int(env, argv[0], &a) ||
+      !enif_get_int(env, argv[1], &b)) {
+      return enif_make_badarg(env);
+  }
 
   int result = a == b ? 0 : (a > b ? 1 : -1);
   return enif_make_int(env, result);

--- a/_posts/2015-12-05-using-c-from-elixir-with-nifs.md
+++ b/_posts/2015-12-05-using-c-from-elixir-with-nifs.md
@@ -296,7 +296,9 @@ In order to wrap `db_query`, we'll need to retrieve the resource that we returne
 static ERL_NIF_TERM
 db_query_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   db_conn_t **conn_res;
-  enif_get_resource(env, argv[0], DB_RES_TYPE, (void *) &conn_res);
+  if (!enif_get_resource(env, argv[0], DB_RES_TYPE, (void *) &conn_res)) {
+    return enif_make_badarg(env);
+  }
 
   db_conn_t *conn = *conn_res;
 


### PR DESCRIPTION
First commit is what I (sverkeren) mentioned in your blog comments.

1. Check return value of `enif_get_resource()`
2. Also check return value of `enif_get_int()`
3. Fix errors in the memory handling of `db_conn_t`.
4. Modernize the text regarding resource terms nowadays (since OTP 20) being _references_  rather than empty binaries.