### PR TITLE
Show that socket is set to :once from the beginning

### DIFF
--- a/content/posts/2015-06-19-handling-tcp-connections-in-elixir/index.md
+++ b/content/posts/2015-06-19-handling-tcp-connections-in-elixir/index.md
@@ -188,6 +188,13 @@ We just have to remember to reactivate the socket when we receive a `{:tcp, ...}
 defmodule Redis do
   # ...as before...
 
+  def init(state) do
+    opts = [:binary, active: :once]
+    # ...as before...
+  end
+
+ # ...as before...
+
   def handle_info({:tcp, socket, msg}, %{socket: socket} = state) do
     # Allow the socket to send us the next message.
     :inet.setopts(socket, active: :once)


### PR DESCRIPTION
Hey Andrea,

Thank you for the article. I hope this minor addition may be helpful in understanding  how 

>  To avoid that, we can change active: true to the more conservative active: :once: this way, only one TCP messages is delivered as an Erlang message, and then the socket goes back to active: false

fits into the code.

Kind regards,
Yevhenii 