### PR TITLE
fix: grammar in statem post

### DIFF
--- a/content/posts/2019-04-14-connection-managers-with-gen_statem/index.md
+++ b/content/posts/2019-04-14-connection-managers-with-gen_statem/index.md
@@ -68,7 +68,7 @@ A helpful habit when designing state machines is to draw a diagram of the state 
 
 ### Implementing the state machine
 
-Let's turn this diagram into a functioning `gen_statem`. The first thing to do is to create a `Connection` module and add specify that it's an implementation of the `:gen_statem` behaviour. We'll also define an internal struct that we'll use as the data carried by the state machine. The data will contain the host and port to connect/reconnect to, the TCP socket, and a map of request ID to caller waiting for a response.
+Let's turn this diagram into a functioning `gen_statem`. The first thing to do is to create a `Connection` module and specify that it's an implementation of the `:gen_statem` behaviour. We'll also define an internal struct that we'll use as the data carried by the state machine. The data will contain the host and port to connect/reconnect to, the TCP socket, and a map of request ID to caller waiting for a response.
 
 ```elixir
 defmodule Connection do


### PR DESCRIPTION
Was referring to your (extremely helpful) blog post about get_statem, since I'm in need of it for building a backoff supervisor for TV Labs.

Noticed a little grammar issue, thanks for the great post!