### PR TITLE
fix: raw/endraw

### DIFF
--- a/content/posts/2019-04-14-connection-managers-with-gen_statem/index.md
+++ b/content/posts/2019-04-14-connection-managers-with-gen_statem/index.md
@@ -266,7 +266,6 @@ We've now got a pretty neat connection process that holds the TCP connection to 
 
 Let's start by setting the timeout when we enter the disconnected state.
 
-{% raw %}
 ```elixir
 def disconnected(:enter, :connected, data) do
   # Same as before: logging, replying to
@@ -276,7 +275,6 @@ def disconnected(:enter, :connected, data) do
   {:keep_state, data, actions}
 end
 ```
-{% endraw %}
 
 Our timeout will fire after 500 milliseconds We use `nil` as its term since we're not carrying any information alongside the timeout other than its name (`:reconnect`). When the timeout expires, we need to handle it in `disconnected/3`:
 


### PR DESCRIPTION
I'm assuming this was leftover from a former way you were rendering code?

<img width="779" alt="Screenshot 2025-05-17 at 6 16 37 PM" src="https://github.com/user-attachments/assets/9011ac10-c8fe-428c-9ddd-abbbcc561750" />
